### PR TITLE
Switch out deprecated NSCalendarUnit enum values

### DIFF
--- a/SSZipArchive.m
+++ b/SSZipArchive.m
@@ -318,7 +318,7 @@
 
 - (void)zipInfo:(zip_fileinfo*)zipInfo setDate:(NSDate*)date {
     NSCalendar *currentCalendar = [NSCalendar currentCalendar];
-    uint flags = NSYearCalendarUnit | NSMonthCalendarUnit | NSDayCalendarUnit | NSHourCalendarUnit | NSMinuteCalendarUnit | NSSecondCalendarUnit;
+    uint flags = NSCalendarUnitYear | NSCalendarUnitMonth | NSCalendarUnitDay | NSCalendarUnitHour | NSCalendarUnitMinute | NSCalendarUnitSecond;
     NSDateComponents *components = [currentCalendar components:flags fromDate:date];
     zipInfo->tmz_date.tm_sec = (unsigned int)components.second;
     zipInfo->tmz_date.tm_min = (unsigned int)components.minute;


### PR DESCRIPTION
When compiling on 10.10 or later, clang would issue warnings about the use of deprecated `NSCalendarUnit` enum values. These have been replaced with the non-deprecated values that are functionally identical.